### PR TITLE
add a little responsivity for smaller screen

### DIFF
--- a/client/app/views/styles/application.styl
+++ b/client/app/views/styles/application.styl
@@ -230,6 +230,7 @@ ul#task-list-done
 
     .container
         margin auto
+        width 100%
 
         .fa-bars
             display inline-block

--- a/client/app/views/styles/application.styl
+++ b/client/app/views/styles/application.styl
@@ -176,6 +176,7 @@ ul#task-list-done
         input
             width 100%
             padding 6px
+            text-overflow ellipsis
 
             border 1px solid transparent
             &:hover

--- a/client/app/views/styles/application.styl
+++ b/client/app/views/styles/application.styl
@@ -241,6 +241,8 @@ ul#task-list-done
             display inline-block
             border-bottom 0
             margin 10px auto 0 20px
+    .task .button
+        width 45px
 
 @media (min-width: 1900px)
     .container


### PR DESCRIPTION
I made 2 changes:
- make Tasky use all the available space to display the tasks.
- reduce Todo/Done buttons width in order to let the maximum available space for the description field.
